### PR TITLE
fix: 태그 API 가 연관된 태그만 노출하도록 변경됨에 따라 테스트 코드에서 더미 태그 생성 시 연관된 스터디그룹을 하나…

### DIFF
--- a/apps/studygroup/tests/tag/test_read_random_tag_list.py
+++ b/apps/studygroup/tests/tag/test_read_random_tag_list.py
@@ -3,12 +3,17 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-from apps.studygroup.tests.factories import TagFactory
+from apps.studygroup.tests.factories import (
+    OpenedByDeadlineStudyGroupFactory,
+    TagFactory,
+)
 
 
 class TagTestCase(APITestCase):
     def setUp(self):
-        TagFactory.create_batch(10, name=factory.Faker("uuid4"))
+        associated_studygroup = OpenedByDeadlineStudyGroupFactory()
+        for tag in TagFactory.create_batch(10, name=factory.Faker("uuid4")):
+            associated_studygroup.tags.add(tag)
 
     def test_read_random_tags_default_is_3(self):
         """


### PR DESCRIPTION
… 포함하도록 수정